### PR TITLE
Fix uninitialised values

### DIFF
--- a/src/xvdr/XVDRData.cpp
+++ b/src/xvdr/XVDRData.cpp
@@ -665,6 +665,8 @@ PVR_ERROR cXVDRData::GetRecordingsList(PVR_HANDLE handle)
     tag.strDirectory    = vresp->extract_String();
     tag.strRecordingId  = vresp->extract_String();
     tag.strStreamURL    = "";
+    tag.iGenreType      = 0;
+    tag.iGenreSubType   = 0;
 
     PVR->TransferRecordingEntry(handle, &tag);
 


### PR DESCRIPTION
Details from valgrind:
==7240== Conditional jump or move depends on uninitialised value(s)
==7240==    at 0xAE6E99: EPG::CEpg::ConvertGenreIdToString(int, int) (Epg.cpp:872)
==7240==    by 0xCDE174: PVR::CPVRRecording::CPVRRecording(PVR_RECORDING const&, unsigned int) (PVRRecording.cpp:54)
==7240==    by 0x9D51FF: ADDON::CAddonCallbacksPVR::PVRTransferRecordingEntry(void_, PVR_HANDLE_STRUCT_, PVR_RECORDING const_) (AddonCallbacksPVR.cpp:165)
==7240==    by 0x1DA245BE: cXVDRData::GetRecordingsList(PVR_HANDLE_STRUCT_) (in /usr/local/lib/xbmc/addons/pvr.vdr.xvdr/XBMC_VDR_xvdr.pvr)
==7240==    by 0x846799: PVR::CPVRClient::GetRecordings(PVR::CPVRRecordings_) (PVRClient.cpp:571)
==7240==    by 0x851356: PVR::CPVRClients::GetRecordings(PVR::CPVRRecordings_) (PVRClients.cpp:790)
==7240==    by 0xCE059C: PVR::CPVRRecordings::UpdateFromClients() (PVRRecordings.cpp:47)
==7240==    by 0xCDF762: PVR::CPVRRecordings::Update() (PVRRecordings.cpp:177)
==7240==    by 0xCDF968: PVR::CPVRRecordings::Load() (PVRRecordings.cpp:158)
==7240==    by 0xCB5AA2: PVR::CPVRManager::Load() (PVRManager.cpp:206)
==7240==    by 0xCB8875: PVR::CPVRManager::Process() (PVRManager.cpp:260)
==7240==    by 0xD468FF: CThread::staticThread(void*) (Thread.cpp:177)
==7240==  Uninitialised value was created by a stack allocation
==7240==    at 0x4013595: _dl_runtime_resolve (dl-trampoline.S:42)
