### PR TITLE
Fix datatype passed to LOG() on x86_64 systems

### DIFF
--- a/src/xvdr/XVDRSession.cpp
+++ b/src/xvdr/XVDRSession.cpp
@@ -125,7 +125,7 @@ bool cXVDRSession::Login()
     m_protocol  = protocol;
 
     if (m_name.empty())
-      XBMC->Log(LOG_NOTICE, "Logged in at '%lu+%i' to '%s' Version: '%s' with protocol version '%lu'",
+      XBMC->Log(LOG_NOTICE, "Logged in at '%u+%i' to '%s' Version: '%s' with protocol version '%u'",
         vdrTime, vdrTimeOffset, ServerName, ServerVersion, protocol);
 
     delete[] ServerName;


### PR DESCRIPTION
I am sending you the last bugfix for the error detected with valgrind. The xvdr plugin doesn't generate any more errors on my system (besides some errors in libz.so - but this is another story).

regards :)
