### PR TITLE
Bump API to 1.2.0

### DIFF
--- a/src/libxvdr/include/xbmc_pvr_types.h
+++ b/src/libxvdr/include/xbmc_pvr_types.h
@@ -64,7 +64,11 @@ struct DemuxPacket;
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20
 
-#define XBMC_PVR_API_VERSION "1.0.0"
+/* current PVR API version */
+#define XBMC_PVR_API_VERSION "1.2.0"
+
+/* min. PVR API version */
+#define XBMC_PVR_MIN_API_VERSION "1.2.0"
 
 #ifdef __cplusplus
 extern "C" {
@@ -142,17 +146,17 @@ extern "C" {
       unsigned int iCodecType;         /*!< @brief (required) codec type id */
       unsigned int iCodecId;           /*!< @brief (required) codec id */
       char         strLanguage[4];     /*!< @brief (required) language id */
-      unsigned int iIdentifier;        /*!< @brief (required) stream id */
-      unsigned int iFPSScale;          /*!< @brief (required) scale of 1000 and a rate of 29970 will result in 29.97 fps */
-      unsigned int iFPSRate;           /*!< @brief (required) FPS rate */
-      unsigned int iHeight;            /*!< @brief (required) height of the stream reported by the demuxer */
-      unsigned int iWidth;             /*!< @brief (required) width of the stream reported by the demuxer */
+      int          iIdentifier;        /*!< @brief (required) stream id */
+      int          iFPSScale;          /*!< @brief (required) scale of 1000 and a rate of 29970 will result in 29.97 fps */
+      int          iFPSRate;           /*!< @brief (required) FPS rate */
+      int          iHeight;            /*!< @brief (required) height of the stream reported by the demuxer */
+      int          iWidth;             /*!< @brief (required) width of the stream reported by the demuxer */
       float        fAspect;            /*!< @brief (required) display aspect ratio of the stream */
-      unsigned int iChannels;          /*!< @brief (required) amount of channels */
-      unsigned int iSampleRate;        /*!< @brief (required) sample rate */
-      unsigned int iBlockAlign;        /*!< @brief (required) block alignment */
-      unsigned int iBitRate;           /*!< @brief (required) bit rate */
-      unsigned int iBitsPerSample;     /*!< @brief (required) bits per sample */
+      int          iChannels;          /*!< @brief (required) amount of channels */
+      int          iSampleRate;        /*!< @brief (required) sample rate */
+      int          iBlockAlign;        /*!< @brief (required) block alignment */
+      int          iBitRate;           /*!< @brief (required) bit rate */
+      int          iBitsPerSample;     /*!< @brief (required) bits per sample */
      } stream[PVR_STREAM_MAX_STREAMS]; /*!< @brief (required) the streams */
    } ATTRIBUTE_PACKED PVR_STREAM_PROPERTIES;
 
@@ -262,6 +266,7 @@ extern "C" {
   typedef struct PVRClient
   {
     const char*  (__cdecl* GetPVRAPIVersion)(void);
+    const char*  (__cdecl* GetMininumPVRAPIVersion)(void);
     PVR_ERROR    (__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
     PVR_ERROR    (__cdecl* GetStreamProperties)(PVR_STREAM_PROPERTIES*);
     const char*  (__cdecl* GetBackendName)(void);
@@ -313,6 +318,7 @@ extern "C" {
     void         (__cdecl* DemuxAbort)(void);
     void         (__cdecl* DemuxFlush)(void);
     DemuxPacket* (__cdecl* DemuxRead)(void);
+    unsigned int (__cdecl* GetChannelSwitchDelay)(void);
   } PVRClient;
 
 #ifdef __cplusplus

--- a/src/xvdr/XBMCAddon.cpp
+++ b/src/xvdr/XBMCAddon.cpp
@@ -655,6 +655,12 @@ const char* GetPVRAPIVersion(void)
   return strApiVersion;
 }
 
+const char* GetMininumPVRAPIVersion(void)
+{
+  static const char *strMinApiVersion = XBMC_PVR_MIN_API_VERSION;
+  return strMinApiVersion;
+}
+
 /** UNUSED API FUNCTIONS */
 PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -670,4 +676,5 @@ const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &recording, int count) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
+unsigned int GetChannelSwitchDelay(void) { return 0; }
 }

--- a/src/xvdr/include/xbmc_pvr_dll.h
+++ b/src/xvdr/include/xbmc_pvr_dll.h
@@ -44,6 +44,14 @@ extern "C"
   const char* GetPVRAPIVersion(void);
 
   /*!
+   * Get the XBMC_PVR_MIN_API_VERSION that was used to compile this add-on.
+   * Used to check if this add-on is compatible with XBMC.
+   * @return The XBMC_PVR_MIN_API_VERSION that was used to compile this add-on.
+   * @remarks Valid implementation required.
+   */
+  const char* GetMininumPVRAPIVersion(void);
+
+  /*!
    * Get the list of features that this add-on provides.
    * Called by XBMC to query the add-on's capabilities.
    * Used to check which options should be presented in the UI, which methods to call, etc.
@@ -498,12 +506,21 @@ extern "C"
   //@}
 
   /*!
+   * Delay to use when using switching channels for add-ons not providing an input stream.
+   * If the add-on does provide an input stream, then this method will not be called.
+   * Those add-ons can do that in OpenLiveStream() if needed.
+   * @return The delay in milliseconds.
+   */
+  unsigned int GetChannelSwitchDelay(void);
+
+  /*!
    * Called by XBMC to assign the function pointers of this add-on to pClient.
    * @param pClient The struct to assign the function pointers to.
    */
   void __declspec(dllexport) get_addon(struct PVRClient* pClient)
   {
     pClient->GetPVRAPIVersion               = GetPVRAPIVersion;
+    pClient->GetMininumPVRAPIVersion        = GetMininumPVRAPIVersion;
     pClient->GetAddonCapabilities           = GetAddonCapabilities;
     pClient->GetStreamProperties            = GetStreamProperties;
     pClient->GetConnectionString            = GetConnectionString;
@@ -551,6 +568,7 @@ extern "C"
     pClient->SwitchChannel                  = SwitchChannel;
     pClient->SignalStatus                   = SignalStatus;
     pClient->GetLiveStreamURL               = GetLiveStreamURL;
+    pClient->GetChannelSwitchDelay          = GetChannelSwitchDelay;
 
     pClient->OpenRecordedStream             = OpenRecordedStream;
     pClient->CloseRecordedStream            = CloseRecordedStream;


### PR DESCRIPTION
The changes contained in this PR makes the XVDR addon compatible with mainline XBMC and the API bump to 1.2.0.
