### PR TITLE
Use AM_CPPFLAGS

### DIFF
--- a/src/libxvdr/src/Makefile.am
+++ b/src/libxvdr/src/Makefile.am
@@ -57,7 +57,7 @@ libxvdr_la_LDFLAGS = \
 	-avoid-version
 
 
-CPPFLAGS = \
+AM_CPPFLAGS = \
 	$(ARCH_DEFINES)
 
 INCLUDES = -I$(srcdir)/../include -D__STDC_CONSTANT_MACROS

--- a/src/xvdr/Makefile.am
+++ b/src/xvdr/Makefile.am
@@ -41,7 +41,7 @@ libxvdraddon_la_LIBADD += \
 	$(PTHREAD_LIBS)
 endif
 
-CPPFLAGS = \
+AM_CPPFLAGS = \
 	$(ARCH_DEFINES)
 
 INCLUDES = \


### PR DESCRIPTION
Don't override CPPFLAGS. See
http://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html
