### PR TITLE
Bump API compatibility to 1.6.0

### DIFF
--- a/src/xvdr/XBMCAddon.cpp
+++ b/src/xvdr/XBMCAddon.cpp
@@ -749,4 +749,6 @@ long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
 const char * GetLiveStreamURL(const PVR_CHANNEL &channel) { return ""; }
 unsigned int GetChannelSwitchDelay(void) { return 0; }
+bool SeekTime(int time, bool backwards, double *startpts) { return false; }
+void SetSpeed(int speed) {};
 }

--- a/src/xvdr/XBMCCallbacks.cpp
+++ b/src/xvdr/XBMCCallbacks.cpp
@@ -401,7 +401,6 @@ PVR_STREAM_PROPERTIES::PVR_STREAM& operator<< (PVR_STREAM_PROPERTIES::PVR_STREAM
 	lhs.iIdentifier = rhs.Identifier;
 	lhs.iPhysicalId = rhs.PhysicalId;
 	lhs.iSampleRate = rhs.SampleRate;
-	lhs.iStreamIndex = rhs.Index;
 	lhs.iWidth = rhs.Width;
 	strncpy(lhs.strLanguage, rhs.Language.c_str(), sizeof(lhs.strLanguage));
 

--- a/src/xvdr/include/xbmc_pvr_dll.h
+++ b/src/xvdr/include/xbmc_pvr_dll.h
@@ -532,6 +532,23 @@ extern "C"
   void PauseStream(bool bPaused);
 
   /*!
+   * Notify the pvr addon/demuxer that XBMC wishes to seek the stream by time
+   * @param time The amount of time to shift the stream
+   * @param backwards True if this seek is negative
+   * @param startpts can be updated to point to where display should start
+   * @return True if the seek operation was possible
+   * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
+   */
+  bool SeekTime(int time, bool backwards, double *startpts);
+
+  /*!
+   * Notify the pvr addon/demuxer that XBMC wishes to change playback speed
+   * @param speed The requested playback speed
+   * @remarks Optional, and only used if addon has its own demuxer.
+   */
+  void SetSpeed(int speed);
+
+  /*!
    * Called by XBMC to assign the function pointers of this add-on to pClient.
    * @param pClient The struct to assign the function pointers to.
    */
@@ -590,6 +607,8 @@ extern "C"
     pClient->CanPauseStream                 = CanPauseStream;
     pClient->PauseStream                    = PauseStream;
     pClient->CanSeekStream                  = CanSeekStream;
+    pClient->SeekTime                       = SeekTime;
+    pClient->SetSpeed                       = SetSpeed;
 
     pClient->OpenRecordedStream             = OpenRecordedStream;
     pClient->CloseRecordedStream            = CloseRecordedStream;

--- a/src/xvdr/include/xbmc_pvr_types.h
+++ b/src/xvdr/include/xbmc_pvr_types.h
@@ -72,10 +72,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "1.5.0"
+#define XBMC_PVR_API_VERSION "1.6.0"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "1.5.0"
+#define XBMC_PVR_MIN_API_VERSION "1.6.0"
 
 #ifdef __cplusplus
 extern "C" {
@@ -151,7 +151,6 @@ extern "C" {
     unsigned int iStreamCount;
     struct PVR_STREAM
     {
-      unsigned int iStreamIndex;       /*!< @brief (required) stream index */
       unsigned int iPhysicalId;        /*!< @brief (required) physical index */
       unsigned int iCodecType;         /*!< @brief (required) codec type id */
       unsigned int iCodecId;           /*!< @brief (required) codec id */
@@ -335,6 +334,8 @@ extern "C" {
     bool         (__cdecl* CanPauseStream)(void);
     void         (__cdecl* PauseStream)(bool);
     bool         (__cdecl* CanSeekStream)(void);
+    bool         (__cdecl* SeekTime)(int, bool, double*);
+    void         (__cdecl* SetSpeed)(int);
   } PVRClient;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR makes XVDR work with latest HEAD.

The two new functions are only added as stubs, and am not sure about the Index variable in "class Stream", but at least it makes LiveTV play something again :)
