### PR TITLE
[win32] workaround a crash in GetLanguageCode()

### DIFF
--- a/src/xvdr/XBMCCallbacks.cpp
+++ b/src/xvdr/XBMCCallbacks.cpp
@@ -100,7 +100,11 @@ std::string cXBMCCallbacks::GetLanguageCode()
 
   if(string != NULL) {
     code = string;
+#ifdef _WIN32
+    Log(DEBUG, "Possible leak caused by Win32 workaround in %s", __FUNCTION__);
+#else
     XBMC->FreeString(string);
+#endif
   }
 
   return code;


### PR DESCRIPTION
For some reason, when going the PVR-API-recommended way of GetDVDMenuLanguage() followed by FreeString() afterwards, this causes a crash on win32. Other platforms (linux tested) don't seem to cause problems. So workaround the crash by simply not freeing the two or three byte long string on reconnect to the XVDR server, risking a possible leak. As added bonus, inform users that a possible leak occured.

On a side note, I checked the other PVR addons. Only VNSI makes use of GetDVDMenuLanguage(), and doesn't care at all about freeing the string allocation, so I guess this will work until this gets resolved (in core?).
