### PR TITLE
fix debian dir

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: xbmc-addon-xvdr
 Section: misc
 Priority: extra
 Maintainer: Alexander Pipelka <alexander.pipelka@gmail.com>
-Build-Depends: debhelper (>= 5), cdbs
+Build-Depends: debhelper (>= 5), cdbs, zlib1g-dev, autotools-dev, libtool
 Standards-Version: 3.8.0
 
 Package: xbmc-addon-xvdr

--- a/debian/rules
+++ b/debian/rules
@@ -7,13 +7,14 @@
 	dh $@
 
 override_dh_auto_configure:
+	sh autogen.sh
 	dh_auto_configure -- --prefix=/usr/lib/xbmc
 
 override_dh_auto_build:
 	dh_auto_build -- all $(MAKE_OPTIONS)
 
 override_dh_auto_clean:
-	$(MAKE) -o .dependencies clean $(MAKE_OPTIONS)
+	$(MAKE) -o .dependencies clean $(MAKE_OPTIONS) ||:
 
 override_dh_shlibdeps:
 	dpkg-shlibdeps -Tdebian/xbmc-addon-xvdr.substvars $(CURDIR)/debian/xbmc-addon-xvdr/usr/lib/xbmc/addons/pvr.vdr.xvdr/XBMC_VDR_xvdr.pvr


### PR DESCRIPTION
Hello,
in order to do a clean build on Launchpad I had to modify the debian dir so it includes all build-dependencies, does not fail if there is nothing to clean up and run autogen.sh properly
