### PR TITLE
fixed for current MinGW32-based Windows builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ ISAPPLE=false
 
 case $host in
   *-*-cygwin* | *-*-mingw32*)
-    LDFLAGS+="-no-undefined -no-cygwin"
+    LDFLAGS+="-no-undefined"
     ISMINGW32=true
     ADDONNAME=XBMC_VDR_xvdr_WIN32.pvr
     SOEXT=dll

--- a/src/libxvdr/src/os-config.h
+++ b/src/libxvdr/src/os-config.h
@@ -24,6 +24,7 @@
 
 // WINDOWS
 #ifdef WIN32
+#include <stdint.h>
 
 #define syslog(s, msg, ...) std::cout << msg << std::endl;
 #define _WIN32_WINNT 0x0501


### PR DESCRIPTION
seems that stdint.h is available, so we better use it
no-cygwin is not supported anymore, so drop it.